### PR TITLE
better handling of lines with macros / ignoring files

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ def project do
 
 The `output` option indicates the output folder for the generated file.
 
+Optionally, the `ignore_paths` option can be a list of prefixes to ignore when generating the coverage report.
+
+```elixir
+test_coverage: [tool: LcovEx, output: "cover", ignore_paths: ["test/"]],
+```
+
 ## Usage
 
 Run tests with coverage:

--- a/lib/lcov_ex.ex
+++ b/lib/lcov_ex.ex
@@ -20,28 +20,40 @@ defmodule LcovEx do
     end
 
     output = opts[:output]
+    ignored_paths = Keyword.get(opts, :ignore_paths, [])
 
     fn ->
       Mix.shell().info("\nGenerating lcov file ... ")
 
       lcov =
-        Enum.map(:cover.modules() |> Enum.sort(), fn mod ->
-          path = mod.module_info(:compile)[:source] |> to_string() |> Path.relative_to_cwd()
-
-          {:ok, fun_data} = :cover.analyse(mod, :calls, :function)
-          {functions_coverage, %{fnf: fnf, fnh: fnh}} = Stats.function_coverage_data(fun_data)
-
-          {:ok, lines_data} = :cover.analyse(mod, :calls, :line)
-          {lines_coverage, %{lf: lf, lh: lh}} = Stats.line_coverage_data(lines_data)
-
-          Formatter.format_lcov(mod, path, functions_coverage, fnf, fnh, lines_coverage, lf, lh)
-        end)
-        |> Enum.join()
+        :cover.modules()
+        |> Enum.sort()
+        |> Enum.map(&calculate_module_coverage(&1, ignored_paths))
 
       File.mkdir_p!(output)
       path = "#{output}/lcov.info"
       File.write!(path, lcov, [:write])
       Mix.shell().info("\nFile successfully created at #{path}")
     end
+  end
+
+  defp calculate_module_coverage(mod, ignored_paths) do
+    path = mod.module_info(:compile)[:source] |> to_string() |> Path.relative_to_cwd()
+
+    if Enum.any?(ignored_paths, &String.starts_with?(path, &1)) do
+      []
+    else
+      calculate_and_format_coverage(mod, path)
+    end
+  end
+
+  defp calculate_and_format_coverage(mod, path) do
+    {:ok, fun_data} = :cover.analyse(mod, :calls, :function)
+    {functions_coverage, %{fnf: fnf, fnh: fnh}} = Stats.function_coverage_data(fun_data)
+
+    {:ok, lines_data} = :cover.analyse(mod, :calls, :line)
+    {lines_coverage, %{lf: lf, lh: lh}} = Stats.line_coverage_data(lines_data)
+
+    Formatter.format_lcov(mod, path, functions_coverage, fnf, fnh, lines_coverage, lf, lh)
   end
 end

--- a/lib/lcov_ex/formatter.ex
+++ b/lib/lcov_ex/formatter.ex
@@ -12,7 +12,16 @@ defmodule LcovEx.Formatter do
   @doc """
   Create a lcov specification for a module.
   """
-  @spec format_lcov(mod(), path(), [coverage_info(), ...], integer(), integer(), [coverage_info(), ...], integer(), integer()) :: binary()
+  @spec format_lcov(
+          mod(),
+          path(),
+          [coverage_info(), ...],
+          integer(),
+          integer(),
+          [coverage_info(), ...],
+          integer(),
+          integer()
+        ) :: binary()
   def format_lcov(mod, path, functions_coverage, fnf, fnh, lines_coverage, lf, lh) do
     # TODO FN
     """

--- a/lib/lcov_ex/formatter.ex
+++ b/lib/lcov_ex/formatter.ex
@@ -9,6 +9,8 @@ defmodule LcovEx.Formatter do
   @type path :: binary()
   @type coverage_info :: {binary(), integer()}
 
+  @newline "\n"
+
   @doc """
   Create a lcov specification for a module.
   """
@@ -24,32 +26,43 @@ defmodule LcovEx.Formatter do
         ) :: binary()
   def format_lcov(mod, path, functions_coverage, fnf, fnh, lines_coverage, lf, lh) do
     # TODO FN
-    """
-    TN:#{mod}
-    SF:#{path}
-    #{fnda(functions_coverage)}
-    FNF:#{fnf}
-    FNH:#{fnh}
-    #{da(lines_coverage)}
-    LF:#{lf}
-    LH:#{lh}
-    end_of_record
-    """
+    [
+      "TN:",
+      Atom.to_string(mod),
+      @newline,
+      "SF:",
+      path,
+      @newline,
+      fnda(functions_coverage),
+      "FNF:",
+      Integer.to_string(fnf),
+      @newline,
+      "FNH:",
+      Integer.to_string(fnh),
+      @newline,
+      da(lines_coverage),
+      "LF:",
+      Integer.to_string(lf),
+      @newline,
+      "LH:",
+      Integer.to_string(lh),
+      @newline,
+      "end_of_record",
+      @newline
+    ]
   end
 
   # FNDA:<execution count>,<function name>
   defp fnda(functions_coverage) do
     Enum.map(functions_coverage, fn {function_name, execution_count} ->
-      "FNDA:#{execution_count},#{function_name}"
+      ["FNDA:", Integer.to_string(execution_count), ?,, function_name, @newline]
     end)
-    |> Enum.join("\n")
   end
 
   # DA:<line number>,<execution count>[,<checksum>]
   defp da(lines_coverage) do
     Enum.map(lines_coverage, fn {line_number, execution_count} ->
-      "DA:#{line_number},#{execution_count}"
+      ["DA:", Integer.to_string(line_number), ?,, Integer.to_string(execution_count), @newline]
     end)
-    |> Enum.join("\n")
   end
 end

--- a/lib/lcov_ex/stats.ex
+++ b/lib/lcov_ex/stats.ex
@@ -39,10 +39,10 @@ defmodule LcovEx.Stats do
   ## Examples
 
       iex> LcovEx.Stats.line_coverage_data([{{MyModule, 0}, 3}, {{MyModule, 0}, 0}, {{MyModule, 8}, 0}])
-      {[{"8", 0}], %{lf: 1, lh: 0}}
+      {[{8, 0}], %{lf: 1, lh: 0}}
 
       iex> LcovEx.Stats.line_coverage_data([{{MyModule, 1}, 12}, {{MyModule, 1}, 0}, {{MyModule, 2}, 0}])
-      {[{"1", 12}, {"2", 0}], %{lf: 2, lh: 1}}
+      {[{1, 12}, {2, 0}], %{lf: 2, lh: 1}}
 
   """
   @spec line_coverage_data(cover_analyze_line_output()) ::
@@ -55,15 +55,15 @@ defmodule LcovEx.Stats do
             acc
 
           {^previous_line, count} ->
-            [{line_str, previous_count} | rest] = list
+            [{line, previous_count} | rest] = list
             count = max(count, previous_count)
 
             lh = increment_line_hit(lh, count, previous_count)
 
-            {[{line_str, count} | rest], previous_line, lf, lh}
+            {[{line, count} | rest], previous_line, lf, lh}
 
           {{_mod, line} = previous_line, count} ->
-            list = [{"#{line}", count} | list]
+            list = [{line, count} | list]
             lf = lf + 1
             lh = increment_line_hit(lh, count, 0)
             {list, previous_line, lf, lh}
@@ -71,7 +71,7 @@ defmodule LcovEx.Stats do
       end)
 
     {Enum.reverse(list_reversed), %{lf: lf, lh: lh}}
-          end
+  end
 
   defp increment_line_hit(lh, count, previous_count)
   defp increment_line_hit(lh, 0, _), do: lh

--- a/lib/lcov_ex/stats.ex
+++ b/lib/lcov_ex/stats.ex
@@ -18,7 +18,8 @@ defmodule LcovEx.Stats do
   @spec function_coverage_data(cover_analyze_function_output()) ::
           {[coverage_info(), ...], %{fnf: integer(), fnh: integer()}}
   def function_coverage_data(fun_data) do
-    Enum.reduce_while(fun_data, {[], %{fnf: 0, fnh: 0}}, fn data, acc = {list, %{fnf: fnf, fnh: fnh}} ->
+    Enum.reduce_while(fun_data, {[], %{fnf: 0, fnh: 0}}, fn data,
+                                                            acc = {list, %{fnf: fnf, fnh: fnh}} ->
       # TODO get FN + line by inspecting file
       case data do
         {{_, :__info__, _1}, _} ->
@@ -44,7 +45,8 @@ defmodule LcovEx.Stats do
   @spec line_coverage_data(cover_analyze_line_output()) ::
           {[coverage_info(), ...], %{lf: integer(), lh: integer()}}
   def line_coverage_data(lines_data) do
-    Enum.reduce_while(lines_data, {[], %{lf: 0, lh: 0}}, fn data, acc = {list, %{lf: lf, lh: lh}} ->
+    Enum.reduce_while(lines_data, {[], %{lf: 0, lh: 0}}, fn data,
+                                                            acc = {list, %{lf: lf, lh: lh}} ->
       case data do
         {{_, 0}, _} ->
           {:cont, acc}

--- a/test/lcov_ex/formatter_test.exs
+++ b/test/lcov_ex/formatter_test.exs
@@ -3,21 +3,29 @@ defmodule LcovEx.FormatterTest do
 
   describe "ExampleProject" do
     test "run mix test --cover with LcovEx" do
-      assert LcovEx.Formatter.format_lcov(FakeModule, "path/to/file.ex", [{"foo/0",1},{"bar/2",0}], 2, 1, [{"3",1},{"5",0}], 2, 1) ==
-        """
-        TN:Elixir.FakeModule
-        SF:path/to/file.ex
-        FNDA:1,foo/0
-        FNDA:0,bar/2
-        FNF:2
-        FNH:1
-        DA:3,1
-        DA:5,0
-        LF:2
-        LH:1
-        end_of_record
-        """
+      assert LcovEx.Formatter.format_lcov(
+               FakeModule,
+               "path/to/file.ex",
+               [{"foo/0", 1}, {"bar/2", 0}],
+               2,
+               1,
+               [{"3", 1}, {"5", 0}],
+               2,
+               1
+             ) ==
+               """
+               TN:Elixir.FakeModule
+               SF:path/to/file.ex
+               FNDA:1,foo/0
+               FNDA:0,bar/2
+               FNF:2
+               FNH:1
+               DA:3,1
+               DA:5,0
+               LF:2
+               LH:1
+               end_of_record
+               """
     end
   end
 end
-

--- a/test/lcov_ex/formatter_test.exs
+++ b/test/lcov_ex/formatter_test.exs
@@ -3,15 +3,17 @@ defmodule LcovEx.FormatterTest do
 
   describe "ExampleProject" do
     test "run mix test --cover with LcovEx" do
-      assert LcovEx.Formatter.format_lcov(
-               FakeModule,
-               "path/to/file.ex",
-               [{"foo/0", 1}, {"bar/2", 0}],
-               2,
-               1,
-               [{"3", 1}, {"5", 0}],
-               2,
-               1
+      assert IO.iodata_to_binary(
+               LcovEx.Formatter.format_lcov(
+                 FakeModule,
+                 "path/to/file.ex",
+                 [{"foo/0", 1}, {"bar/2", 0}],
+                 2,
+                 1,
+                 [{3, 1}, {5, 0}],
+                 2,
+                 1
+               )
              ) ==
                """
                TN:Elixir.FakeModule


### PR DESCRIPTION
Thanks for creating this module! When trying to apply to a project, I ran across two issues that this PR addresses.

## Ignoring generated files
We have some generate files which were picked up by the coverage tests. However, we don't want those files counted against us when measuring. This adds an optional argument which ignores those paths.


## Better handling of lines with Macros

Macro-generated functions all appear to be on the same line, which results in unusual coverage reports where the same line is reported multiple times. This is adjusted to report the greatest number of calls for a given line (the sum would also be an option here), as well as appropriately adjusting the LF and LH values.