### PR TITLE
Run as task `mix lcov`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,22 +20,38 @@ Please let me know if you made it work in your previously unlisted favorite edit
 Add to your dependencies:
 
 ```elixir
-def deps do
-  [
-    {:lcov_ex, "~> 0.1", only: :test, runtime: false}
-  ]
-end
+  def deps do
+    [
+      {:lcov_ex, "~> 0.2", only: :test, runtime: false}
+    ]
+  end
 ```
 
-Then, select `LcovEx` as your test coverage tool in your project configuration:
+## Usage
+
+```shell
+mix lcov
+```
+
+File should be created at `./cover/lcov.info` by default.
+
+### As test coverage tool
+
+Alternatively, you can set up `LcovEx` as your test coverage tool in your project configuration:
 
 ```elixir
-def project do
-  [
-    ...
-    test_coverage: [tool: LcovEx, output: "cover"],
-    ...
-  ]
+  def project do
+    [
+      ...
+      test_coverage: [tool: LcovEx, output: "cover"],
+      ...
+    ]
+```
+
+And then, run with:
+
+```shell
+mix test --cover
 ```
 
 The `output` option indicates the output folder for the generated file.
@@ -43,20 +59,14 @@ The `output` option indicates the output folder for the generated file.
 Optionally, the `ignore_paths` option can be a list of prefixes to ignore when generating the coverage report.
 
 ```elixir
-test_coverage: [tool: LcovEx, output: "cover", ignore_paths: ["test/"]],
+  def project do
+    [
+      ...
+      test_coverage: [tool: LcovEx, output: "cover", ignore_paths: ["test/"]]
+      ...
+    ]
 ```
-
-## Usage
-
-Run tests with coverage:
-
-```shell
-mix test --cover
-```
-
-File should be created at `./cover/lcov.info` by default.
 
 ## TODOs
 
 - Add missing `FN` lines, for the sake of completion.
-- Make it work as a `Task` to avoid overwriting the `test_coverage` tool config.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add to your dependencies:
 ```elixir
   def deps do
     [
-      {:lcov_ex, "~> 0.2", only: :test, runtime: false}
+      {:lcov_ex, "~> 0.2", only: [:dev, :test], runtime: false}
     ]
   end
 ```

--- a/example_project/mix.exs
+++ b/example_project/mix.exs
@@ -20,7 +20,7 @@ defmodule ExampleProject.MixProject do
 
   defp deps do
     [
-      {:lcov_ex, path: "../"}
+      {:lcov_ex, path: "../", only: [:dev, :test]}
     ]
   end
 end

--- a/lib/lcov_ex/formatter.ex
+++ b/lib/lcov_ex/formatter.ex
@@ -23,7 +23,7 @@ defmodule LcovEx.Formatter do
           [coverage_info(), ...],
           integer(),
           integer()
-        ) :: binary()
+        ) :: [binary()]
   def format_lcov(mod, path, functions_coverage, fnf, fnh, lines_coverage, lf, lh) do
     # TODO FN
     [

--- a/lib/lcov_ex/mix_file_helper.ex
+++ b/lib/lcov_ex/mix_file_helper.ex
@@ -72,56 +72,6 @@ defmodule LcovEx.MixFileHelper do
     :ok
   end
 
-  @doc """
-  Update mix deps.
-  """
-  @spec update_deps(path(), keyword()) :: :ok
-  def update_deps(mix_path, new_deps) do
-    # Format mix.exs file
-    System.cmd("mix", ["format", mix_path])
-
-    # Get file as AST representation
-    {:defmodule, _, [_, [do: {_, _, ast_nodes}]]} =
-      Code.string_to_quoted!(File.read!(mix_path), token_metadata: true)
-
-    # Obtain the deps AST node
-    deps_ast_node =
-      Enum.find(ast_nodes, fn ast -> match?({:def, _, [{:deps, _, _}, _]}, ast) end)
-
-    # Get deps and file start and ending line numbers for replacement
-    {_, token_metadata, [deps_ast_tuple, [do: deps]]} = deps_ast_node
-    deps_start_line = token_metadata[:line]
-    deps_end_line = token_metadata[:end_of_expression][:line]
-
-    # Update the deps
-    # We try to maintain the key positions or append any new deps to the bottom
-    new_deps =
-      Enum.reduce(new_deps, deps, fn {key, value}, deps ->
-        case Keyword.pop(deps, key) do
-          {nil, list} -> list ++ [{key, value}]
-          _ -> put_in(deps[key], value)
-        end
-      end)
-
-    new_deps_ast_node = put_elem(deps_ast_node, 2, [deps_ast_tuple, [do: new_deps]])
-
-    # Reconvert to string
-    deps_string_replacement =
-      new_deps_ast_node
-      |> Macro.to_string()
-      |> String.replace_prefix("def(deps) do", "def deps do")
-      |> String.replace_suffix("end", "end\n")
-
-    replace_range = deps_start_line..deps_end_line
-
-    # Replace the deps config into the file
-    replace_range(mix_path, replace_range, deps_string_replacement)
-
-    # Format new mix.exs file
-    System.cmd("mix", ["format", mix_path])
-    :ok
-  end
-
   #
   # Private functions
   #

--- a/lib/lcov_ex/mix_file_helper.ex
+++ b/lib/lcov_ex/mix_file_helper.ex
@@ -1,0 +1,121 @@
+defmodule LcovEx.MixFileHelper do
+  @type path :: binary()
+
+  @doc """
+  Backup file in path by duplicating it into an `.old` file.
+  """
+  @spec backup(path()) :: path()
+  def backup(path) do
+    path_old = "#{path}.old"
+    File.cp!(path, path_old)
+    path_old
+  end
+
+  @doc """
+  Recover file in path from preexisting `.old` file.
+  """
+  @spec recover(path()) :: :ok
+  def recover(path) do
+    path_old = "#{path}.old"
+    File.cp!(path_old, path)
+    File.rm!(path_old)
+    :ok
+  end
+
+  @doc """
+  Update mix project configurations.
+  """
+  @spec update_project_config(path(), keyword()) :: :ok
+  def update_project_config(mix_path, new_configs) do
+    # Format mix.exs file
+    System.cmd("mix", ["format", mix_path])
+
+    # Get file as AST representation
+    {:defmodule, _, [_, [do: {_, _, ast_nodes}]]} =
+      Code.string_to_quoted!(File.read!(mix_path), token_metadata: true)
+
+    # Obtain the project AST node
+    project_ast_node =
+      Enum.find(ast_nodes, fn ast -> match?({:def, _, [{:project, _, _}, _]}, ast) end)
+
+    # Get project config and file start and ending line numbers for replacement
+    {_, token_metadata, [project_ast_tuple, [do: config]]} = project_ast_node
+    project_start_line = token_metadata[:line]
+    project_end_line = token_metadata[:end_of_expression][:line]
+
+    # Replace the configs
+    # We try to maintain the key positions or append any new configs to the bottom
+    new_config =
+      Enum.reduce(new_configs, config, fn {key, value}, config ->
+        case Keyword.pop(config, key) do
+          {nil, list} -> list ++ [{key, value}]
+          _ -> put_in(config[key], value)
+        end
+      end)
+
+    new_project_ast_node = put_elem(project_ast_node, 2, [project_ast_tuple, [do: new_config]])
+
+    # Reconvert to string
+    project_string_replacement =
+      new_project_ast_node
+      |> Macro.to_string()
+      |> String.replace_prefix("def(project) do", "def project do")
+      |> String.replace_suffix("end", "end\n")
+
+    replace_range = project_start_line..project_end_line
+
+    # Replace the project config into the file
+    replace_range(mix_path, replace_range, project_string_replacement)
+
+    # Format new mix.exs file
+    System.cmd("mix", ["format", mix_path])
+    :ok
+  end
+
+  #
+  # Private functions
+  #
+
+  defp replace_range(path, range, replacement) when is_binary(replacement) do
+    path_tmp = "#{path}.tmp"
+    File.cp!(path, path_tmp)
+
+    try do
+      File.rm!(path)
+      new_file = File.open!(path, [:append])
+
+      File.open!(path_tmp, [:read], fn old_file ->
+        copy_and_replace(old_file, new_file, range, replacement)
+      end)
+    catch
+      _, _ ->
+        File.cp!(path_tmp, path)
+    after
+      File.rm(path_tmp)
+    end
+  end
+
+  defp copy_and_replace(old_file, new_file, range, string_replacement) do
+    IO.read(old_file, :line)
+    |> copy_and_replace(1, old_file, new_file, range, string_replacement)
+  end
+
+  defp copy_and_replace(:eof, _, _, _, _, _) do
+    :ok
+  end
+
+  defp copy_and_replace(_, index, old_file, new_file, range_start.._ = range, string_replacement)
+       when index == range_start do
+    IO.write(new_file, string_replacement)
+
+    IO.read(old_file, :line)
+    |> copy_and_replace(index + 1, old_file, new_file, range, string_replacement)
+  end
+
+  defp copy_and_replace(line, index, old_file, new_file, range, string_replacement) do
+    unless index in range, do: IO.write(new_file, line)
+
+    IO.read(old_file, :line)
+    |> copy_and_replace(index + 1, old_file, new_file, range, string_replacement)
+  end
+end

--- a/lib/tasks/lcov.ex
+++ b/lib/tasks/lcov.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Lcov do
   @moduledoc "Generates lcov test coverage files for the application"
   @shortdoc "Generates lcov files"
   @preferred_cli_env :test
-  @recursive true
+  # TODO @recursive true
 
   use Mix.Task
   alias LcovEx.MixFileHelper

--- a/lib/tasks/lcov.ex
+++ b/lib/tasks/lcov.ex
@@ -1,0 +1,27 @@
+defmodule Mix.Tasks.Lcov do
+  @moduledoc "Generates lcov test coverage files for the application"
+  @shortdoc "Generates lcov files"
+  @preferred_cli_env :test
+  @recursive true
+
+  use Mix.Task
+  alias LcovEx.MixFileHelper
+
+  @doc """
+  Generates the `lcov.info` file.
+  """
+  @impl Mix.Task
+  def run(args) do
+    path = Enum.at(args, 0) || File.cwd!()
+    mix_path = "#{path}/mix.exs" |> String.replace("//", "/")
+    MixFileHelper.backup(mix_path)
+
+    try do
+      config = [test_coverage: [tool: LcovEx]]
+      MixFileHelper.update_project_config(mix_path, config)
+      System.cmd("mix", ["test", "--cover"], cd: path, into: IO.stream(:stdio, :line))
+    after
+      MixFileHelper.recover(mix_path)
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule LcovEx.MixProject do
   use Mix.Project
 
-  @version "0.1.1"
+  @version "0.2.0"
 
   def project do
     [
@@ -10,7 +10,6 @@ defmodule LcovEx.MixProject do
       version: @version,
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
-      test_coverage: [tool: LcovEx],
       deps: deps(),
       docs: docs(),
       package: package()
@@ -20,7 +19,7 @@ defmodule LcovEx.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :tools]
     ]
   end
 

--- a/test/lcov_ex/formatter_test.exs
+++ b/test/lcov_ex/formatter_test.exs
@@ -2,7 +2,7 @@ defmodule LcovEx.FormatterTest do
   use ExUnit.Case
 
   describe "ExampleProject" do
-    test "run mix test --cover with LcovEx" do
+    test "format_lcov" do
       assert IO.iodata_to_binary(
                LcovEx.Formatter.format_lcov(
                  FakeModule,

--- a/test/tasks/lcov_test.exs
+++ b/test/tasks/lcov_test.exs
@@ -1,0 +1,51 @@
+defmodule LcovEx.Tasks.LcovTest do
+  use ExUnit.Case, async: true
+
+  describe "ExampleProject" do
+    test "lcov task" do
+      assert Mix.Tasks.Lcov.run(["./example_project"])
+
+      assert File.read!("example_project/cover/lcov.info") == output()
+      # Cleanup
+      File.rm("example_project/cover/lcov.info")
+    end
+
+    test "mix lcov" do
+      assert {output, 0} = System.cmd("mix", ["lcov"], cd: "example_project")
+
+      assert output =~ "Generating lcov file ..."
+      assert output =~ "File successfully created at cover/lcov.info"
+
+      assert File.read!("example_project/cover/lcov.info") == output()
+
+      # Cleanup
+      File.rm("example_project/cover/lcov.info")
+    end
+  end
+
+  defp output do
+    """
+    TN:Elixir.ExampleProject
+    SF:lib/example_project.ex
+    FNDA:1,covered/0
+    FNDA:0,not_covered/0
+    FNF:2
+    FNH:1
+    DA:5,1
+    DA:9,0
+    LF:2
+    LH:1
+    end_of_record
+    TN:Elixir.ExampleProject.ExampleModule
+    SF:lib/example_project/example_module.ex
+    FNDA:1,cover/0
+    FNDA:1,get_value/0
+    FNF:2
+    FNH:2
+    DA:5,1
+    LF:1
+    LH:1
+    end_of_record
+    """
+  end
+end


### PR DESCRIPTION
- Added `MixFileHelper` module to manipulate `mix.exs` configs.
- Created `mix lcov` task (create `lcov.info` file without need of additional configuration changes).
- Updated README.