### PR TITLE
Improvements for umbrella projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ mix lcov
 
 File should be created at `./cover/lcov.info` by default.
 
+To run silently use the `--quiet` option:
+
+```shell
+mix lcov --quiet
+```
+
 ### As test coverage tool
 
 Alternatively, you can set up `LcovEx` as your test coverage tool in your project configuration:
@@ -66,6 +72,10 @@ Optionally, the `ignore_paths` option can be a list of prefixes to ignore when g
       ...
     ]
 ```
+
+### In umbrella projects
+
+Make sure that every app has `lcov_ex` added as a dependency (see [_Installation_](#installation)).
 
 ## TODOs
 

--- a/example_project/mix.exs
+++ b/example_project/mix.exs
@@ -7,7 +7,6 @@ defmodule ExampleProject.MixProject do
       version: "0.1.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
-      test_coverage: [tool: LcovEx],
       deps: deps()
     ]
   end

--- a/example_umbrella_project/.formatter.exs
+++ b/example_umbrella_project/.formatter.exs
@@ -1,0 +1,5 @@
+# Used by "mix format"
+[
+  inputs: ["mix.exs", "config/*.exs"],
+  subdirectories: ["apps/*"]
+]

--- a/example_umbrella_project/.gitignore
+++ b/example_umbrella_project/.gitignore
@@ -1,0 +1,23 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/example_umbrella_project/apps/example_project/.gitignore
+++ b/example_umbrella_project/apps/example_project/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+lcov_ex-*.tar
+

--- a/example_umbrella_project/apps/example_project/lib/example_project.ex
+++ b/example_umbrella_project/apps/example_project/lib/example_project.ex
@@ -1,0 +1,11 @@
+defmodule ExampleProject do
+  @moduledoc false
+
+  def covered() do
+    ExampleProject.ExampleModule.cover()
+  end
+
+  def not_covered() do
+    ExampleProject.ExampleModule.cover()
+  end
+end

--- a/example_umbrella_project/apps/example_project/lib/example_project/example_module.ex
+++ b/example_umbrella_project/apps/example_project/lib/example_project/example_module.ex
@@ -1,0 +1,11 @@
+defmodule ExampleProject.ExampleModule do
+  @moduledoc false
+
+  def cover() do
+    get_value()
+  end
+
+  defp get_value() do
+    :covered
+  end
+end

--- a/example_umbrella_project/apps/example_project/mix.exs
+++ b/example_umbrella_project/apps/example_project/mix.exs
@@ -7,7 +7,6 @@ defmodule ExampleProject.MixProject do
       version: "0.1.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
-      test_coverage: [tool: LcovEx],
       deps: deps()
     ]
   end
@@ -19,6 +18,6 @@ defmodule ExampleProject.MixProject do
   end
 
   defp deps do
-    []
+    [{:lcov_ex, path: "../../../", only: [:dev, :test]}]
   end
 end

--- a/example_umbrella_project/apps/example_project/mix.exs
+++ b/example_umbrella_project/apps/example_project/mix.exs
@@ -1,0 +1,24 @@
+defmodule ExampleProject.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :example_project,
+      version: "0.1.0",
+      elixir: "~> 1.9",
+      start_permanent: Mix.env() == :prod,
+      test_coverage: [tool: LcovEx],
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    []
+  end
+end

--- a/example_umbrella_project/apps/example_project/test/example_project_test.exs
+++ b/example_umbrella_project/apps/example_project/test/example_project_test.exs
@@ -1,0 +1,8 @@
+defmodule ExampleProjectTest do
+  use ExUnit.Case
+  doctest ExampleProject
+
+  test "run covered function" do
+    assert ExampleProject.covered() == :covered
+  end
+end

--- a/example_umbrella_project/apps/example_project/test/test_helper.exs
+++ b/example_umbrella_project/apps/example_project/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/example_umbrella_project/apps/example_project_2/.gitignore
+++ b/example_umbrella_project/apps/example_project_2/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+lcov_ex-*.tar
+

--- a/example_umbrella_project/apps/example_project_2/lib/example_project_2.ex
+++ b/example_umbrella_project/apps/example_project_2/lib/example_project_2.ex
@@ -1,0 +1,11 @@
+defmodule ExampleProject2 do
+  @moduledoc false
+
+  def covered() do
+    ExampleProject2.ExampleModule.cover()
+  end
+
+  def not_covered() do
+    ExampleProject2.ExampleModule.cover()
+  end
+end

--- a/example_umbrella_project/apps/example_project_2/lib/example_project_2/example_module.ex
+++ b/example_umbrella_project/apps/example_project_2/lib/example_project_2/example_module.ex
@@ -1,0 +1,11 @@
+defmodule ExampleProject2.ExampleModule do
+  @moduledoc false
+
+  def cover() do
+    get_value()
+  end
+
+  defp get_value() do
+    :covered
+  end
+end

--- a/example_umbrella_project/apps/example_project_2/mix.exs
+++ b/example_umbrella_project/apps/example_project_2/mix.exs
@@ -7,7 +7,6 @@ defmodule ExampleProject2.MixProject do
       version: "0.1.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
-      test_coverage: [tool: LcovEx],
       deps: deps()
     ]
   end
@@ -19,6 +18,6 @@ defmodule ExampleProject2.MixProject do
   end
 
   defp deps do
-    []
+    [{:lcov_ex, path: "../../../", only: [:dev, :test]}]
   end
 end

--- a/example_umbrella_project/apps/example_project_2/mix.exs
+++ b/example_umbrella_project/apps/example_project_2/mix.exs
@@ -1,0 +1,24 @@
+defmodule ExampleProject2.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :example_project_2,
+      version: "0.1.0",
+      elixir: "~> 1.9",
+      start_permanent: Mix.env() == :prod,
+      test_coverage: [tool: LcovEx],
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    []
+  end
+end

--- a/example_umbrella_project/apps/example_project_2/test/example_project_2_test.exs
+++ b/example_umbrella_project/apps/example_project_2/test/example_project_2_test.exs
@@ -1,0 +1,8 @@
+defmodule ExampleProject2Test do
+  use ExUnit.Case
+  doctest ExampleProject
+
+  test "run covered function" do
+    assert ExampleProject2.covered() == :covered
+  end
+end

--- a/example_umbrella_project/apps/example_project_2/test/example_project_2_test.exs
+++ b/example_umbrella_project/apps/example_project_2/test/example_project_2_test.exs
@@ -1,6 +1,6 @@
 defmodule ExampleProject2Test do
   use ExUnit.Case
-  doctest ExampleProject
+  doctest ExampleProject2
 
   test "run covered function" do
     assert ExampleProject2.covered() == :covered

--- a/example_umbrella_project/apps/example_project_2/test/test_helper.exs
+++ b/example_umbrella_project/apps/example_project_2/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/example_umbrella_project/config/config.exs
+++ b/example_umbrella_project/config/config.exs
@@ -1,0 +1,18 @@
+# This file is responsible for configuring your umbrella
+# and **all applications** and their dependencies with the
+# help of the Config module.
+#
+# Note that all applications in your umbrella share the
+# same configuration and dependencies, which is why they
+# all use the same configuration file. If you want different
+# configurations or dependencies per app, it is best to
+# move said applications out of the umbrella.
+import Config
+
+# Sample configuration:
+#
+#     config :logger, :console,
+#       level: :info,
+#       format: "$date $time [$level] $metadata$message\n",
+#       metadata: [:user_id]
+#

--- a/example_umbrella_project/mix.exs
+++ b/example_umbrella_project/mix.exs
@@ -16,8 +16,6 @@ defmodule ExampleUmbrellaProject.MixProject do
   #
   # Run "mix help deps" for examples and options.
   defp deps do
-    [
-      {:lcov_ex, path: "../", only: [:dev, :test]}
-    ]
+    []
   end
 end

--- a/example_umbrella_project/mix.exs
+++ b/example_umbrella_project/mix.exs
@@ -1,0 +1,23 @@
+defmodule ExampleUmbrellaProject.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      apps_path: "apps",
+      version: "0.1.0",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Dependencies listed here are available only for this
+  # project and cannot be accessed from applications inside
+  # the apps folder.
+  #
+  # Run "mix help deps" for examples and options.
+  defp deps do
+    [
+      {:lcov_ex, path: "../", only: [:dev, :test]}
+    ]
+  end
+end

--- a/lib/lcov_ex.ex
+++ b/lib/lcov_ex.ex
@@ -34,15 +34,7 @@ defmodule LcovEx do
       path = "#{output}/lcov.info"
       File.write!(path, lcov, [:write])
 
-      rel_path =
-        if Mix.Task.recursing?() do
-          umbrella_path = File.cwd!() |> Path.join("../..") |> Path.expand()
-          File.cwd!() |> Path.join(path) |> Path.relative_to(umbrella_path)
-        else
-          path
-        end
-
-      log_info("\nFile successfully created at #{rel_path}", opts)
+      log_info("\nFile successfully created at #{path}", opts)
       :cover.stop()
     end
   end

--- a/lib/tasks/lcov.ex
+++ b/lib/tasks/lcov.ex
@@ -2,9 +2,11 @@ defmodule Mix.Tasks.Lcov do
   @moduledoc "Generates lcov test coverage files for the application"
   @shortdoc "Generates lcov files"
   @preferred_cli_env :test
+  @recursive true
 
   use Mix.Task
   alias LcovEx.MixFileHelper
+  require Logger
 
   @doc """
   Generates the `lcov.info` file.
@@ -17,9 +19,17 @@ defmodule Mix.Tasks.Lcov do
     MixFileHelper.backup(mix_path)
 
     try do
-      config = [test_coverage: [tool: LcovEx, quiet: opts[:quiet]]]
+      config = [test_coverage: [tool: LcovEx]]
       MixFileHelper.update_project_config(mix_path, config)
-      System.cmd("mix", ["test", "--cover"], cd: path, into: IO.stream(:stdio, :line))
+
+      opts =
+        if opts[:quiet] do
+          [cd: path]
+        else
+          [cd: path, into: IO.stream(:stdio, :line)]
+        end
+
+      System.cmd("mix", ["test", "--cover"], opts)
     after
       MixFileHelper.recover(mix_path)
     end

--- a/lib/tasks/lcov.ex
+++ b/lib/tasks/lcov.ex
@@ -2,7 +2,6 @@ defmodule Mix.Tasks.Lcov do
   @moduledoc "Generates lcov test coverage files for the application"
   @shortdoc "Generates lcov files"
   @preferred_cli_env :test
-  # TODO @recursive true
 
   use Mix.Task
   alias LcovEx.MixFileHelper
@@ -12,13 +11,13 @@ defmodule Mix.Tasks.Lcov do
   """
   @impl Mix.Task
   def run(args) do
-    {opts, files} = OptionParser.parse!(args, strict: [quiet: :boolean, umbrella: :boolean])
+    {opts, files} = OptionParser.parse!(args, strict: [quiet: :boolean])
     path = Enum.at(files, 0) || File.cwd!()
     mix_path = "#{path}/mix.exs" |> String.replace("//", "/")
     MixFileHelper.backup(mix_path)
 
     try do
-      config = [test_coverage: [tool: LcovEx, quiet: opts[:quiet], umbrella: opts[:umbrella]]]
+      config = [test_coverage: [tool: LcovEx, quiet: opts[:quiet]]]
       MixFileHelper.update_project_config(mix_path, config)
       System.cmd("mix", ["test", "--cover"], cd: path, into: IO.stream(:stdio, :line))
     after

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule LcovEx.MixProject do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.2.1"
 
   def project do
     [

--- a/test/lcov_ex/formatter_test.exs
+++ b/test/lcov_ex/formatter_test.exs
@@ -3,18 +3,17 @@ defmodule LcovEx.FormatterTest do
 
   describe "ExampleProject" do
     test "format_lcov" do
-      assert IO.iodata_to_binary(
-               LcovEx.Formatter.format_lcov(
-                 FakeModule,
-                 "path/to/file.ex",
-                 [{"foo/0", 1}, {"bar/2", 0}],
-                 2,
-                 1,
-                 [{3, 1}, {5, 0}],
-                 2,
-                 1
-               )
-             ) ==
+      assert LcovEx.Formatter.format_lcov(
+               FakeModule,
+               "path/to/file.ex",
+               [{"foo/0", 1}, {"bar/2", 0}],
+               2,
+               1,
+               [{3, 1}, {5, 0}],
+               2,
+               1
+             )
+             |> IO.iodata_to_binary() ==
                """
                TN:Elixir.FakeModule
                SF:path/to/file.ex

--- a/test/lcov_ex_test.exs
+++ b/test/lcov_ex_test.exs
@@ -1,7 +1,21 @@
 defmodule LcovExTest do
   use ExUnit.Case
+  alias LcovEx.MixFileHelper
 
   describe "ExampleProject" do
+    setup do
+      mix_path = "#{File.cwd!()}/example_project/mix.exs" |> String.replace("//", "/")
+      MixFileHelper.backup(mix_path)
+      config = [test_coverage: [tool: LcovEx]]
+      MixFileHelper.update_project_config(mix_path, config)
+
+      on_exit(fn ->
+        # Cleanup
+        MixFileHelper.recover(mix_path)
+        File.rm("example_project/cover/lcov.info")
+      end)
+    end
+
     test "run mix test --cover with LcovEx" do
       System.cmd("mix", ["test", "--cover"], env: [{"LCOV", "true"}], cd: "example_project")
 
@@ -29,9 +43,6 @@ defmodule LcovExTest do
                LH:1
                end_of_record
                """
-
-      # Cleanup
-      File.rm("example_project/cover/lcov.info")
     end
   end
 end

--- a/test/tasks/lcov_test.exs
+++ b/test/tasks/lcov_test.exs
@@ -34,16 +34,22 @@ defmodule LcovEx.Tasks.LcovTest do
       File.rm("example_project/cover/lcov.info")
     end
 
-    test "mix lcov --umbrella" do
-      assert {output, 0} = System.cmd("mix", ["lcov", "--umbrella"], cd: "example_project")
+    test "mix lcov for umbrella project" do
+      assert {output, 0} =
+               System.cmd("mix", ["lcov"], cd: "example_umbrella_project")
 
       assert output =~ "Generating lcov file ..."
-      assert output =~ "File successfully created at cover/lcov.info"
+      assert output =~ "File successfully created at apps/example_project/cover/lcov.info"
+      assert output =~ "File successfully created at apps/example_project_2/cover/lcov.info"
 
-      assert File.read!("example_project/cover/lcov.info") == umbrella_output()
+      assert File.read!("example_umbrella_project/apps/example_project/cover/lcov.info") ==
+               output()
+
+      assert File.read!("example_umbrella_project/apps/example_project_2/cover/lcov.info") ==
+               output_2()
 
       # Cleanup
-      File.rm("example_project/cover/lcov.info")
+      File.rm("example_umbrella_project/apps/example_project/cover/lcov.info")
     end
   end
 
@@ -73,10 +79,10 @@ defmodule LcovEx.Tasks.LcovTest do
     """
   end
 
-  defp umbrella_output do
+  defp output_2 do
     """
-    TN:Elixir.ExampleProject
-    SF:#{root_dir()}/example_project/lib/example_project.ex
+    TN:Elixir.ExampleProject2
+    SF:lib/example_project_2.ex
     FNDA:1,covered/0
     FNDA:0,not_covered/0
     FNF:2
@@ -86,8 +92,8 @@ defmodule LcovEx.Tasks.LcovTest do
     LF:2
     LH:1
     end_of_record
-    TN:Elixir.ExampleProject.ExampleModule
-    SF:#{root_dir()}/example_project/lib/example_project/example_module.ex
+    TN:Elixir.ExampleProject2.ExampleModule
+    SF:lib/example_project_2/example_module.ex
     FNDA:1,cover/0
     FNDA:1,get_value/0
     FNF:2
@@ -97,9 +103,5 @@ defmodule LcovEx.Tasks.LcovTest do
     LH:1
     end_of_record
     """
-  end
-
-  defp root_dir do
-    Path.expand(__DIR__ <> "/../..")
   end
 end

--- a/test/tasks/lcov_test.exs
+++ b/test/tasks/lcov_test.exs
@@ -2,12 +2,17 @@ defmodule LcovEx.Tasks.LcovTest do
   use ExUnit.Case, async: true
 
   describe "ExampleProject" do
+    setup do
+      on_exit(fn ->
+        # Cleanup
+        File.rm("example_project/cover/lcov.info")
+      end)
+    end
+
     test "lcov task" do
       assert Mix.Tasks.Lcov.run(["./example_project"])
 
       assert File.read!("example_project/cover/lcov.info") == output()
-      # Cleanup
-      File.rm("example_project/cover/lcov.info")
     end
 
     test "mix lcov" do
@@ -17,9 +22,6 @@ defmodule LcovEx.Tasks.LcovTest do
       assert output =~ "File successfully created at cover/lcov.info"
 
       assert File.read!("example_project/cover/lcov.info") == output()
-
-      # Cleanup
-      File.rm("example_project/cover/lcov.info")
     end
 
     test "mix lcov --quiet" do
@@ -29,27 +31,29 @@ defmodule LcovEx.Tasks.LcovTest do
       refute output =~ "File successfully created at cover/lcov.info"
 
       assert File.read!("example_project/cover/lcov.info") == output()
+    end
+  end
 
-      # Cleanup
-      File.rm("example_project/cover/lcov.info")
+  describe "ExampleUmbrellaProject" do
+    setup do
+      on_exit(fn ->
+        # Cleanup
+        File.rm("example_umbrella_project/apps/example_project/cover/lcov.info")
+        File.rm("example_umbrella_project/apps/example_project_2/cover/lcov.info")
+      end)
     end
 
-    test "mix lcov for umbrella project" do
-      assert {output, 0} =
-               System.cmd("mix", ["lcov"], cd: "example_umbrella_project")
+    test "mix lcov" do
+      assert {output, 0} = System.cmd("mix", ["lcov"], cd: "example_umbrella_project")
 
       assert output =~ "Generating lcov file ..."
-      assert output =~ "File successfully created at apps/example_project/cover/lcov.info"
-      assert output =~ "File successfully created at apps/example_project_2/cover/lcov.info"
+      assert output =~ "File successfully created at cover/lcov.info"
 
       assert File.read!("example_umbrella_project/apps/example_project/cover/lcov.info") ==
                output()
 
       assert File.read!("example_umbrella_project/apps/example_project_2/cover/lcov.info") ==
                output_2()
-
-      # Cleanup
-      File.rm("example_umbrella_project/apps/example_project/cover/lcov.info")
     end
   end
 


### PR DESCRIPTION
- Removes redundant information from `lcov.info` in umbrella apps.
- Adds instructions for the `--quiet` option in README.
- Adds instructions for umbrella projects in README.
- Overall improvement of tests.

Solves #2 