### PR TITLE
Fix recursive strategy for umbrellas

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,6 @@ Optionally, the `ignore_paths` option can be a list of prefixes to ignore when g
     ]
 ```
 
-### In umbrella projects
-
-Make sure that every app has `lcov_ex` added as a dependency (see [_Installation_](#installation)).
-
 ## TODOs
 
 - Add missing `FN` lines, for the sake of completion.

--- a/example_umbrella_project/apps/example_project_2/mix.exs
+++ b/example_umbrella_project/apps/example_project_2/mix.exs
@@ -18,6 +18,6 @@ defmodule ExampleProject2.MixProject do
   end
 
   defp deps do
-    [{:lcov_ex, path: "../../../", only: [:dev, :test]}]
+    []
   end
 end

--- a/lib/lcov_ex.ex
+++ b/lib/lcov_ex.ex
@@ -34,7 +34,15 @@ defmodule LcovEx do
       path = "#{output}/lcov.info"
       File.write!(path, lcov, [:write])
 
-      log_info("\nFile successfully created at #{path}", opts)
+      rel_path =
+        if Mix.Task.recursing?() do
+          umbrella_path = File.cwd!() |> Path.join("../..") |> Path.expand()
+          File.cwd!() |> Path.join(path) |> Path.relative_to(umbrella_path)
+        else
+          path
+        end
+
+      log_info("\nFile successfully created at #{rel_path}", opts)
       :cover.stop()
     end
   end

--- a/lib/tasks/lcov.ex
+++ b/lib/tasks/lcov.ex
@@ -2,7 +2,6 @@ defmodule Mix.Tasks.Lcov do
   @moduledoc "Generates lcov test coverage files for the application"
   @shortdoc "Generates lcov files"
   @preferred_cli_env :test
-  @recursive true
 
   use Mix.Task
   alias LcovEx.MixFileHelper
@@ -15,12 +14,25 @@ defmodule Mix.Tasks.Lcov do
   def run(args) do
     {opts, files} = OptionParser.parse!(args, strict: [quiet: :boolean])
     path = Enum.at(files, 0) || File.cwd!()
-    mix_path = "#{path}/mix.exs" |> String.replace("//", "/")
-    MixFileHelper.backup(mix_path)
+
+    affected_files =
+      case Mix.Project.apps_paths() do
+        nil ->
+          [Path.join([path, "mix.exs"])]
+
+        apps_paths ->
+          for {_app, app_path} <- apps_paths, do: Path.join([path, app_path, "mix.exs"])
+      end
+      |> Enum.map(fn path -> String.replace(path, "//", "/") end)
+
+    Enum.each(affected_files, fn mix_path -> MixFileHelper.backup(mix_path) end)
 
     try do
       config = [test_coverage: [tool: LcovEx]]
-      MixFileHelper.update_project_config(mix_path, config)
+
+      Enum.each(affected_files, fn mix_path ->
+        MixFileHelper.update_project_config(mix_path, config)
+      end)
 
       opts =
         if opts[:quiet] do
@@ -31,7 +43,7 @@ defmodule Mix.Tasks.Lcov do
 
       System.cmd("mix", ["test", "--cover"], opts)
     after
-      MixFileHelper.recover(mix_path)
+      Enum.each(affected_files, fn mix_path -> MixFileHelper.recover(mix_path) end)
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule LcovEx.MixProject do
   use Mix.Project
 
-  @version "0.2.1"
+  @version "0.2.2"
 
   def project do
     [

--- a/test/tasks/lcov_test.exs
+++ b/test/tasks/lcov_test.exs
@@ -47,7 +47,8 @@ defmodule LcovEx.Tasks.LcovTest do
       assert {output, 0} = System.cmd("mix", ["lcov"], cd: "example_umbrella_project")
 
       assert output =~ "Generating lcov file ..."
-      assert output =~ "File successfully created at cover/lcov.info"
+      assert output =~ "File successfully created at apps/example_project/cover/lcov.info"
+      assert output =~ "File successfully created at apps/example_project_2/cover/lcov.info"
 
       assert File.read!("example_umbrella_project/apps/example_project/cover/lcov.info") ==
                output()


### PR DESCRIPTION
Uses a more aggresive approach to replace and recover umbrella mix files in order to improve logs and not require the dependency to be required everywhere.