### PR TITLE
Output one file for umbrellas

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ The docs can be found at [https://hexdocs.pm/lcov_ex](https://hexdocs.pm/lcov_ex
 
 Many test coverage tools use [`lcov`](https://manpages.debian.org/stretch/lcov/geninfo.1.en.html#FILES) files as an input to generate reports.
 
-You can use it as I do to watch inline coverage progress with the following editors:
+You can use it as I do to watch coverage progress in the following editors:
 
-- VSCode, using the [Coverage Gutters](https://github.com/ryanluker/vscode-coverage-gutters) extension.
+- VSCode:
+  - Using the [Coverage Gutters](https://github.com/ryanluker/vscode-coverage-gutters) extension.
+  - Using the [Koverage](https://marketplace.visualstudio.com/items?itemName=tenninebt.vscode-koverage) extension (add "cover" in settings as coverage folder, or output the report to the "coverage" folder, see below).
 - Atom, using the [lcov-info](https://atom.io/packages/lcov-info) extension (it requires you to change the output folder to "coverage", see below).
 
 Please let me know if you made it work in your previously unlisted favorite editor. Or, if you're really nice, just add it to this list yourself :slightly_smiling_face:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,14 @@ To run silently use the `--quiet` option:
 mix lcov --quiet
 ```
 
+To output the file to a differnt folder, use the `--output` option:
+
+```shell
+mix lcov --output coverage
+...
+Coverage file successfully created at coverage/lcov.info
+```
+
 ### As test coverage tool
 
 Alternatively, you can set up `LcovEx` as your test coverage tool in your project configuration:

--- a/example_umbrella_project/apps/example_project_2/lib/example_project_2.ex
+++ b/example_umbrella_project/apps/example_project_2/lib/example_project_2.ex
@@ -5,7 +5,7 @@ defmodule ExampleProject2 do
     ExampleProject2.ExampleModule.cover()
   end
 
-  def not_covered() do
+  def also_covered() do
     ExampleProject2.ExampleModule.cover()
   end
 end

--- a/example_umbrella_project/apps/example_project_2/test/example_project_2_test.exs
+++ b/example_umbrella_project/apps/example_project_2/test/example_project_2_test.exs
@@ -5,4 +5,8 @@ defmodule ExampleProject2Test do
   test "run covered function" do
     assert ExampleProject2.covered() == :covered
   end
+
+  test "run also covered function" do
+    assert ExampleProject2.also_covered() == :covered
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule LcovEx.MixProject do
   use Mix.Project
 
-  @version "0.2.2"
+  @version "0.2.3"
 
   def project do
     [

--- a/test/tasks/lcov_test.exs
+++ b/test/tasks/lcov_test.exs
@@ -18,8 +18,8 @@ defmodule LcovEx.Tasks.LcovTest do
     test "mix lcov" do
       assert {output, 0} = System.cmd("mix", ["lcov"], cd: "example_project")
 
-      assert output =~ "Generating lcov file ..."
-      assert output =~ "File successfully created at cover/lcov.info"
+      assert output =~ "Adding to lcov file..."
+      assert output =~ "Coverage file successfully created at cover/lcov.info"
 
       assert File.read!("example_project/cover/lcov.info") == output()
     end
@@ -27,10 +27,22 @@ defmodule LcovEx.Tasks.LcovTest do
     test "mix lcov --quiet" do
       assert {output, 0} = System.cmd("mix", ["lcov", "--quiet"], cd: "example_project")
 
-      refute output =~ "Generating lcov file ..."
-      refute output =~ "File successfully created at cover/lcov.info"
+      refute output =~ "Adding to lcov file..."
+      refute output =~ "Coverage file successfully created at cover/lcov.info"
 
       assert File.read!("example_project/cover/lcov.info") == output()
+    end
+
+    test "mix lcov --output" do
+      assert {output, 0} =
+               System.cmd("mix", ["lcov", "--output", "coverage"], cd: "example_project")
+
+      assert output =~ "Adding to lcov file..."
+      assert output =~ "Coverage file successfully created at coverage/lcov.info"
+
+      assert File.read!("example_project/coverage/lcov.info") == output()
+    after
+      File.rm_rf!("example_project/coverage")
     end
   end
 
@@ -46,15 +58,11 @@ defmodule LcovEx.Tasks.LcovTest do
     test "mix lcov" do
       assert {output, 0} = System.cmd("mix", ["lcov"], cd: "example_umbrella_project")
 
-      assert output =~ "Generating lcov file ..."
-      assert output =~ "File successfully created at apps/example_project/cover/lcov.info"
-      assert output =~ "File successfully created at apps/example_project_2/cover/lcov.info"
+      assert output =~ "Adding to lcov file..."
+      assert output =~ "Coverage file successfully created at cover/lcov.info"
 
-      assert File.read!("example_umbrella_project/apps/example_project/cover/lcov.info") ==
-               output()
-
-      assert File.read!("example_umbrella_project/apps/example_project_2/cover/lcov.info") ==
-               output_2()
+      assert File.read!("example_umbrella_project/cover/lcov.info") ==
+               output() <> output_2()
     end
   end
 
@@ -88,22 +96,22 @@ defmodule LcovEx.Tasks.LcovTest do
     """
     TN:Elixir.ExampleProject2
     SF:lib/example_project_2.ex
+    FNDA:1,also_covered/0
     FNDA:1,covered/0
-    FNDA:0,not_covered/0
-    FNF:2
-    FNH:1
-    DA:5,1
-    DA:9,0
-    LF:2
-    LH:1
-    end_of_record
-    TN:Elixir.ExampleProject2.ExampleModule
-    SF:lib/example_project_2/example_module.ex
-    FNDA:1,cover/0
-    FNDA:1,get_value/0
     FNF:2
     FNH:2
     DA:5,1
+    DA:9,1
+    LF:2
+    LH:2
+    end_of_record
+    TN:Elixir.ExampleProject2.ExampleModule
+    SF:lib/example_project_2/example_module.ex
+    FNDA:2,cover/0
+    FNDA:2,get_value/0
+    FNF:2
+    FNH:2
+    DA:5,2
     LF:1
     LH:1
     end_of_record


### PR DESCRIPTION
Output one single file for umbrellas at the top level, to make the report compatible with [VSCode Koverage](https://marketplace.visualstudio.com/items?itemName=tenninebt.vscode-koverage) extension.