### PR TITLE
fix: ensure `output_path` exists before writing to it

### DIFF
--- a/lib/lcov_ex.ex
+++ b/lib/lcov_ex.ex
@@ -38,6 +38,7 @@ defmodule LcovEx do
         |> Enum.map(&calculate_module_coverage(&1, ignored_paths))
 
       file_path = "#{output_path}/lcov.info"
+      File.mkdir_p!(output_path)
       File.write!(file_path, lcov, [:append])
 
       :cover.stop()


### PR DESCRIPTION
This was removed (possibly accidentally?) in #8.

Sample failed action: https://github.com/paulswartz/tablespoon/runs/6706490759?check_suite_focus=true