### PR TITLE
Refactor umbrella strategy. Add `--keep` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ mix lcov --output coverage
 Coverage file successfully created at coverage/lcov.info
 ```
 
+### Umbrella projects
+
+For umbrella projects you can choose to keep the individual apps lcov files with the `--keep` option:
+
+```shell
+mix lcov --keep
+...
+Coverage file for my_app created at apps/my_app/cover/lcov.info
+Coverage file for my_other_app created at apps/my_other_app/cover/lcov.info
+
+Coverage file for umbrella created at cover/lcov.info
+```
+
 ### As test coverage tool
 
 Alternatively, you can set up `LcovEx` as your test coverage tool in your project configuration:

--- a/lib/tasks/lcov.ex
+++ b/lib/tasks/lcov.ex
@@ -48,8 +48,8 @@ defmodule Mix.Tasks.Lcov do
           [cd: path, into: IO.stream(:stdio, :line)]
         end
 
-      System.cmd("mix", ["test", "--cover"], task_opts)
-    after
+      {_, 0} = System.cmd("mix", ["test", "--cover"], task_opts)
+
       if Mix.Project.umbrella?() do
         for {app, path} <- Mix.Project.apps_paths() do
           app_lcov_path = Path.join(path, file_path)
@@ -65,6 +65,8 @@ defmodule Mix.Tasks.Lcov do
         log_info("\nCoverage file for umbrella created at #{file_path}", opts)
       end
 
+      :ok
+    after
       Enum.each(affected_files, fn mix_path -> MixFileHelper.recover(mix_path) end)
     end
   end

--- a/lib/tasks/lcov.ex
+++ b/lib/tasks/lcov.ex
@@ -12,7 +12,9 @@ defmodule Mix.Tasks.Lcov do
   """
   @impl Mix.Task
   def run(args) do
-    {opts, files} = OptionParser.parse!(args, strict: [quiet: :boolean, output: :string])
+    {opts, files} =
+      OptionParser.parse!(args, strict: [quiet: :boolean, keep: :boolean, output: :string])
+
     path = Enum.at(files, 0) || File.cwd!()
 
     affected_files =
@@ -47,12 +49,29 @@ defmodule Mix.Tasks.Lcov do
         end
 
       System.cmd("mix", ["test", "--cover"], task_opts)
-
-      unless opts[:quiet] do
-        IO.puts("\nCoverage file successfully created at #{file_path}")
-      end
     after
+      if Mix.Project.umbrella?() do
+        for {app, path} <- Mix.Project.apps_paths() do
+          app_lcov_path = Path.join(path, file_path)
+          File.write!(file_path, File.read!(app_lcov_path), [:append])
+
+          if opts[:keep] do
+            log_info("Coverage file for #{app} created at #{app_lcov_path}", opts)
+          else
+            File.rm!(app_lcov_path)
+          end
+        end
+
+        log_info("\nCoverage file for umbrella created at #{file_path}", opts)
+      end
+
       Enum.each(affected_files, fn mix_path -> MixFileHelper.recover(mix_path) end)
+    end
+  end
+
+  defp log_info(msg, opts) do
+    unless Keyword.get(opts, :quiet, false) do
+      Mix.shell().info(msg)
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule LcovEx.MixProject do
   use Mix.Project
 
-  @version "0.2.3"
+  @version "0.2.4"
 
   def project do
     [

--- a/test/tasks/lcov_test.exs
+++ b/test/tasks/lcov_test.exs
@@ -18,8 +18,8 @@ defmodule LcovEx.Tasks.LcovTest do
     test "mix lcov" do
       assert {output, 0} = System.cmd("mix", ["lcov"], cd: "example_project")
 
-      assert output =~ "Adding to lcov file..."
-      assert output =~ "Coverage file successfully created at cover/lcov.info"
+      assert output =~ "Generating lcov file..."
+      assert output =~ "Coverage file created at cover/lcov.info"
 
       assert File.read!("example_project/cover/lcov.info") == output()
     end
@@ -27,8 +27,8 @@ defmodule LcovEx.Tasks.LcovTest do
     test "mix lcov --quiet" do
       assert {output, 0} = System.cmd("mix", ["lcov", "--quiet"], cd: "example_project")
 
-      refute output =~ "Adding to lcov file..."
-      refute output =~ "Coverage file successfully created at cover/lcov.info"
+      refute output =~ "Generating lcov file..."
+      refute output =~ "Coverage file created at cover/lcov.info"
 
       assert File.read!("example_project/cover/lcov.info") == output()
     end
@@ -37,8 +37,8 @@ defmodule LcovEx.Tasks.LcovTest do
       assert {output, 0} =
                System.cmd("mix", ["lcov", "--output", "coverage"], cd: "example_project")
 
-      assert output =~ "Adding to lcov file..."
-      assert output =~ "Coverage file successfully created at coverage/lcov.info"
+      assert output =~ "Generating lcov file..."
+      assert output =~ "Coverage file created at coverage/lcov.info"
 
       assert File.read!("example_project/coverage/lcov.info") == output()
     after
@@ -50,6 +50,7 @@ defmodule LcovEx.Tasks.LcovTest do
     setup do
       on_exit(fn ->
         # Cleanup
+        File.rm("example_umbrella_project/cover/lcov.info")
         File.rm("example_umbrella_project/apps/example_project/cover/lcov.info")
         File.rm("example_umbrella_project/apps/example_project_2/cover/lcov.info")
       end)
@@ -58,8 +59,20 @@ defmodule LcovEx.Tasks.LcovTest do
     test "mix lcov" do
       assert {output, 0} = System.cmd("mix", ["lcov"], cd: "example_umbrella_project")
 
-      assert output =~ "Adding to lcov file..."
-      assert output =~ "Coverage file successfully created at cover/lcov.info"
+      assert output =~ "Generating lcov file..."
+      assert output =~ "Coverage file for umbrella created at cover/lcov.info"
+
+      assert File.read!("example_umbrella_project/cover/lcov.info") ==
+               output() <> output_2()
+    end
+
+    test "mix lcov --keep" do
+      assert {output, 0} = System.cmd("mix", ["lcov", "--keep"], cd: "example_umbrella_project")
+
+      assert output =~ "Generating lcov file..."
+      assert output =~ "Coverage file for example_project created at apps/example_project/cover/lcov.info"
+      assert output =~ "Coverage file for example_project_2 created at apps/example_project_2/cover/lcov.info"
+      assert output =~ "Coverage file for umbrella created at cover/lcov.info"
 
       assert File.read!("example_umbrella_project/cover/lcov.info") ==
                output() <> output_2()


### PR DESCRIPTION
The umbrella solution for 0.2.3 broke the usage of the lib by configuration.

This change refactors the solution by first creating the individual files for the apps, and then unifying the report in case of an umbrella project.

We also do the following:
- Add the `--keep` option, to keep individual apps lcov files (for umbrellas).
- Improve logs.
- Validate the output of the `mix test --cover` run.