### PR TITLE
Set fixed OTP and Elixir version

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -17,8 +17,8 @@ jobs:
     - name: Set up Elixir
       uses: erlef/setup-elixir@885971a72ed1f9240973bd92ab57af8c1aa68f24
       with:
-        elixir-version: '1.10.3' # Define the elixir version [required]
-        otp-version: '22.3' # Define the OTP version [required]
+        elixir-version: '1.14' # Define the elixir version [required]
+        otp-version: '25.0' # Define the OTP version [required]
     - name: Restore dependencies cache
       uses: actions/cache@v2
       with:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.14
+erlang 25.0

--- a/test/lcov_ex_test.exs
+++ b/test/lcov_ex_test.exs
@@ -39,8 +39,9 @@ defmodule LcovExTest do
                FNF:2
                FNH:2
                DA:5,1
-               LF:1
-               LH:1
+               DA:8,1
+               LF:2
+               LH:2
                end_of_record
                """
     end

--- a/test/lcov_ex_test.exs
+++ b/test/lcov_ex_test.exs
@@ -17,7 +17,7 @@ defmodule LcovExTest do
     end
 
     test "run mix test --cover with LcovEx" do
-      System.cmd("mix", ["test", "--cover"], env: [{"LCOV", "true"}], cd: "example_project")
+      System.cmd("mix", ["test", "--cover"], cd: "example_project")
 
       assert File.read!("example_project/cover/lcov.info") ==
                """

--- a/test/tasks/lcov_test.exs
+++ b/test/tasks/lcov_test.exs
@@ -70,8 +70,13 @@ defmodule LcovEx.Tasks.LcovTest do
       assert {output, 0} = System.cmd("mix", ["lcov", "--keep"], cd: "example_umbrella_project")
 
       assert output =~ "Generating lcov file..."
-      assert output =~ "Coverage file for example_project created at apps/example_project/cover/lcov.info"
-      assert output =~ "Coverage file for example_project_2 created at apps/example_project_2/cover/lcov.info"
+
+      assert output =~
+               "Coverage file for example_project created at apps/example_project/cover/lcov.info"
+
+      assert output =~
+               "Coverage file for example_project_2 created at apps/example_project_2/cover/lcov.info"
+
       assert output =~ "Coverage file for umbrella created at cover/lcov.info"
 
       assert File.read!("example_umbrella_project/cover/lcov.info") ==
@@ -99,8 +104,9 @@ defmodule LcovEx.Tasks.LcovTest do
     FNF:2
     FNH:2
     DA:5,1
-    LF:1
-    LH:1
+    DA:8,1
+    LF:2
+    LH:2
     end_of_record
     """
   end
@@ -125,8 +131,9 @@ defmodule LcovEx.Tasks.LcovTest do
     FNF:2
     FNH:2
     DA:5,2
-    LF:1
-    LH:1
+    DA:8,2
+    LF:2
+    LH:2
     end_of_record
     """
   end


### PR DESCRIPTION
Updated run with Elixir 1.14 and OTP 25.0 (generates a different output).

Also sets a `.tool-versions` file compatible with [`asdf`](https://github.com/asdf-vm/asdf) to keep a stable running environment reference.