### PR TITLE
Run umbrella app tests from umbrella build

### DIFF
--- a/lib/lcov_ex.ex
+++ b/lib/lcov_ex.ex
@@ -70,6 +70,7 @@ defmodule LcovEx do
     path = "#{output}/lcov.info"
     keep? = opts[:keep] || false
     recursing? = Mix.Task.recursing?()
+    arg_path = opts[:arg_path]
     app = Mix.Project.config()[:app]
     app_lcov_path = File.cwd!() |> Path.relative_to(caller_cwd) |> Path.join(path)
 
@@ -78,7 +79,7 @@ defmodule LcovEx do
         # Using --keep option from umbrella
         log_info("\nCoverage file for #{app} created at #{app_lcov_path}")
 
-      not recursing? && File.cwd!() != caller_cwd ->
+      arg_path && File.cwd!() != caller_cwd ->
         # Using an umbrella app path from umbrella
         log_info("\nCoverage file created at #{app_lcov_path}")
 

--- a/lib/tasks/lcov.ex
+++ b/lib/tasks/lcov.ex
@@ -37,7 +37,6 @@ defmodule Mix.Tasks.Lcov do
         """
         mix run -e "#{script}" #{beam_path} "#{task} #{args}"
         """,
-        cd: path,
         env: [{"MIX_ENV", "test"}]
       )
 

--- a/lib/tasks/lcov.run.ex
+++ b/lib/tasks/lcov.run.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Lcov.Run do
   """
   @impl Mix.Task
   def run(args) do
-    {opts, _files} =
+    {opts, files} =
       OptionParser.parse!(args,
         strict: [
           quiet: :boolean,
@@ -34,6 +34,8 @@ defmodule Mix.Tasks.Lcov.Run do
     File.mkdir_p!(output)
     File.rm(file_path)
 
+    arg_path = Enum.at(files, 0)
+
     # Update config for current project on runtime
     config = [
       test_coverage: [
@@ -41,7 +43,8 @@ defmodule Mix.Tasks.Lcov.Run do
         output: output,
         ignore_paths: @ignored_paths,
         cwd: opts[:cwd],
-        keep: opts[:keep]
+        keep: opts[:keep],
+        arg_path: arg_path
       ]
     ]
 
@@ -51,7 +54,8 @@ defmodule Mix.Tasks.Lcov.Run do
     Mix.ProjectStack.pop()
     Mix.ProjectStack.push(project, new_config, mix_path)
 
+    arg_path_test_dir = Path.join("#{arg_path}", "test")
     # Run tests with updated :test_coverage configuration
-    Mix.Task.run("test", ["--cover", "--color"])
+    Mix.Task.run("test", ["--cover", "--color", "#{arg_path_test_dir}"])
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule LcovEx.MixProject do
   use Mix.Project
 
-  @version "0.3.2"
+  @version "0.3.3"
 
   def project do
     [

--- a/test/tasks/lcov_test.exs
+++ b/test/tasks/lcov_test.exs
@@ -120,6 +120,7 @@ defmodule LcovEx.Tasks.LcovTest do
 
       assert output =~ "Generating lcov file..."
       refute output =~ "Coverage file created at cover/lcov.info"
+      refute output =~ "Coverage file created at apps/example_project/cover/lcov.info"
       assert output =~ "Coverage file created at apps/example_project_2/cover/lcov.info"
 
       assert File.read!("example_umbrella_project/apps/example_project_2/cover/lcov.info") ==


### PR DESCRIPTION
# Why?

Previous implementation ran the mix task changing the cwd to the umbrella app folder. This has the fallback of using the app compilation instead of the umbrella's, which restricts the access to other umbrella apps on compile time.

This change avoids changing the cwd when passing the app folder by instead passing the path to the internal test task with `mix test --cover <app_path>/test`.