### PR TITLE
Maintainability improvements

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -27,5 +27,5 @@ jobs:
         restore-keys: ${{ runner.os }}-mix-
     - name: Install dependencies
       run: mix deps.get
-    - name: Run tests
-      run: mix test
+    - name: Run tests with lcov --exit
+      run: mix lcov --exit

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -29,3 +29,26 @@ jobs:
       run: mix deps.get
     - name: Run tests with lcov --exit
       run: mix lcov --exit
+    - name: Upload code coverage
+      uses: actions/upload-artifact@v3
+      with:
+        name: lcov-file
+        path: cover/lcov.info
+
+  coverage_report:
+    name: Generate coverage report
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download code coverage reports
+      uses: actions/download-artifact@v3
+      with:
+        name: lcov-file
+        path: cover
+    - name: Report code coverage
+      uses: kefasjw/lcov-pull-request-report@v1
+      with:
+        # Lcov file location
+        lcov-file: cover/lcov.info
+        # Github token required for getting list of changed files and posting comments
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The docs can be found at [https://hexdocs.pm/lcov_ex](https://hexdocs.pm/lcov_ex
 
 ## Why
 
-### Visual line coverage
+### Visualize line coverage
 
 Many test coverage tools use [`lcov`](https://manpages.debian.org/stretch/lcov/geninfo.1.en.html#FILES) files as an input.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ The docs can be found at [https://hexdocs.pm/lcov_ex](https://hexdocs.pm/lcov_ex
 
 ## Why
 
-Many test coverage tools use [`lcov`](https://manpages.debian.org/stretch/lcov/geninfo.1.en.html#FILES) files as an input to generate reports.
+### Visual line coverage
+
+Many test coverage tools use [`lcov`](https://manpages.debian.org/stretch/lcov/geninfo.1.en.html#FILES) files as an input.
 
 You can use it as I do to watch coverage progress in the following editors:
 
@@ -16,6 +18,12 @@ You can use it as I do to watch coverage progress in the following editors:
 - Atom, using the [lcov-info](https://atom.io/packages/lcov-info) extension (it requires you to change the output folder to "coverage", see below).
 
 Please let me know if you made it work in your previously unlisted favorite editor. Or, if you're really nice, just add it to this list yourself :slightly_smiling_face:
+
+### Coverage report in CI
+
+You can use `mix lcov --exit` in a Github Action CI to safely run your tests and generate the lcov file, and then use that with [a report tool](https://github.com/marketplace/actions/lcov-pull-request-report) to generate a comment with code coverage information in your pull requests.
+
+See [this project's CI configuration](https://github.com/dariodf/lcov_ex/blob/master/.github/workflows/elixir.yml) for more info on how to set it up.
 
 ## Installation
 

--- a/lib/lcov_ex.ex
+++ b/lib/lcov_ex.ex
@@ -70,7 +70,7 @@ defmodule LcovEx do
     path = "#{output}/lcov.info"
     keep? = opts[:keep] || false
     recursing? = Mix.Task.recursing?()
-    arg_path = opts[:arg_path]
+    app_path = opts[:app_path]
     app = Mix.Project.config()[:app]
     app_lcov_path = File.cwd!() |> Path.relative_to(caller_cwd) |> Path.join(path)
 
@@ -79,7 +79,7 @@ defmodule LcovEx do
         # Using --keep option from umbrella
         log_info("\nCoverage file for #{app} created at #{app_lcov_path}")
 
-      arg_path && File.cwd!() != caller_cwd ->
+      app_path && File.cwd!() != caller_cwd ->
         # Using an umbrella app path from umbrella
         log_info("\nCoverage file created at #{app_lcov_path}")
 

--- a/lib/tasks/lcov.ex
+++ b/lib/tasks/lcov.ex
@@ -29,13 +29,14 @@ defmodule Mix.Tasks.Lcov do
     # and then run the task
     script = @load_and_run_task_script
 
+    task_module = Mix.Task.get(task)
     # .beam path for `lcov.run` task
-    beam_path = Mix.Task.get(task) |> :code.which() |> to_string()
+    beam_path = task_module |> :code.which() |> to_string()
 
     test_exit_code =
       Mix.shell().cmd(
         """
-        mix run -e "#{script}" #{beam_path} "#{task} #{args}"
+        mix run -e "#{script}" "#{beam_path}" "#{task_module}" "#{task} #{args}"
         """,
         env: [{"MIX_ENV", "test"}]
       )

--- a/lib/tasks/lcov.run.ex
+++ b/lib/tasks/lcov.run.ex
@@ -34,7 +34,7 @@ defmodule Mix.Tasks.Lcov.Run do
     File.mkdir_p!(output)
     File.rm(file_path)
 
-    arg_path = Enum.at(files, 0)
+    app_path = Enum.at(files, 0)
 
     # Update config for current project on runtime
     config = [
@@ -44,7 +44,7 @@ defmodule Mix.Tasks.Lcov.Run do
         ignore_paths: @ignored_paths,
         cwd: opts[:cwd],
         keep: opts[:keep],
-        arg_path: arg_path
+        app_path: app_path
       ]
     ]
 
@@ -54,8 +54,10 @@ defmodule Mix.Tasks.Lcov.Run do
     Mix.ProjectStack.pop()
     Mix.ProjectStack.push(project, new_config, mix_path)
 
-    arg_path_test_dir = Path.join("#{arg_path}", "test")
+    test_params =
+      ["--cover", "--color"] ++ if app_path, do: [Path.join("#{app_path}", "test")], else: []
+
     # Run tests with updated :test_coverage configuration
-    Mix.Task.run("test", ["--cover", "--color", "#{arg_path_test_dir}"])
+    Mix.Task.run("test", test_params)
   end
 end

--- a/lib/tasks/lcov/load_and_run_task.exs
+++ b/lib/tasks/lcov/load_and_run_task.exs
@@ -1,8 +1,9 @@
 # Script to load a mix task and related dependency modules from beam files on runtime if necessary,
 # and then run the task
-beam_path = System.argv() |> Enum.at(-2)
-task_module = Path.rootname(beam_path) |> String.to_atom()
+beam_path = System.argv() |> Enum.at(0)
+task_module = System.argv() |> Enum.at(1) |> String.to_atom()
 
+# Ensure that task module is loaded
 unless Code.ensure_loaded?(task_module) do
   # Get dependency beam files data
   beam_dir = Path.dirname(beam_path)


### PR DESCRIPTION
This PR does some internal improvements/fixes for ease of maintainability:

- Changes `arg_path` to `app_path`, as it is only used for running tests of umbrella apps.
- Fixes the local `mix lcov` run by passing the `task_module` as a param, as `:code.which()` returns `:cover_compiled` instead of the actual path to the task for the local path traversal dependency in `example_project`.
- Run `mix lcov --exit` instead of `mix test` in CI.
