### PR TITLE
feature: Add `--fail-fast` option to exit early on test failures

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Run tests with lcov --exit --fail-fast
       run: mix lcov --exit --fail-fast
     - name: Upload code coverage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: lcov-file
         path: cover/lcov.info
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download code coverage reports
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: lcov-file
         path: cover

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -27,8 +27,8 @@ jobs:
         restore-keys: ${{ runner.os }}-mix-
     - name: Install dependencies
       run: mix deps.get
-    - name: Run tests with lcov --exit
-      run: mix lcov --exit
+    - name: Run tests with lcov --exit --fail
+      run: mix lcov --exit --fail
     - name: Upload code coverage
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -27,8 +27,8 @@ jobs:
         restore-keys: ${{ runner.os }}-mix-
     - name: Install dependencies
       run: mix deps.get
-    - name: Run tests with lcov --exit --fail
-      run: mix lcov --exit --fail
+    - name: Run tests with lcov --exit --fail-fast
+      run: mix lcov --exit --fail-fast
     - name: Upload code coverage
       uses: actions/upload-artifact@v3
       with:

--- a/README.md
+++ b/README.md
@@ -73,15 +73,19 @@ Exits with a non-zero exit code if the tests fail: the same code that `mix test`
 mix lcov --exit
 ```
 
-#### `--fail`
+#### `--fail-fast`
 
 Fails the task early at the first failed test by passing the `--max-failures 1` option to `mix test`.
 
 ``` shell
-mix lcov --fail
+mix lcov --fail-fast
 ```
 
 Useful in combination with `--exit` for CI.
+
+``` shell
+mix lcov --fail-fast --exit
+```
 
 ### Umbrella projects
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ Exits with a non-zero exit code if the tests fail: the same code that `mix test`
 mix lcov --exit
 ```
 
+#### `--fail`
+
+Fails the task early at the first failed test by passing the `--max-failures 1` option to `mix test`.
+
+``` shell
+mix lcov --fail
+```
+
+Useful in combination with `--exit` for CI.
+
 ### Umbrella projects
 
 By default, running `mix lcov` at the umbrella level will generate the coverage report for all individual apps and then compile them into a single file at `./cover/lcov.info`.

--- a/example_failing_project/test/example_failing_project_test.exs
+++ b/example_failing_project/test/example_failing_project_test.exs
@@ -4,4 +4,8 @@ defmodule ExampleFailingProjectTest do
   test "failure" do
     assert false
   end
+
+  test "second failure" do
+    assert false
+  end
 end

--- a/lib/tasks/lcov.ex
+++ b/lib/tasks/lcov.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.Lcov do
   def run(args) do
     {opts, files} =
       OptionParser.parse!(args,
-        strict: [quiet: :boolean, keep: :boolean, output: :string, exit: :boolean]
+        strict: [quiet: :boolean, keep: :boolean, output: :string, exit: :boolean, fail: :boolean]
       )
 
     if opts[:quiet], do: Mix.shell(Mix.Shell.Quiet)

--- a/lib/tasks/lcov.ex
+++ b/lib/tasks/lcov.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.Lcov do
   def run(args) do
     {opts, files} =
       OptionParser.parse!(args,
-        strict: [quiet: :boolean, keep: :boolean, output: :string, exit: :boolean, fail: :boolean]
+        strict: [quiet: :boolean, keep: :boolean, output: :string, exit: :boolean, fail_fast: :boolean]
       )
 
     if opts[:quiet], do: Mix.shell(Mix.Shell.Quiet)

--- a/lib/tasks/lcov.run.ex
+++ b/lib/tasks/lcov.run.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Lcov.Run do
           keep: :boolean,
           output: :string,
           exit: :boolean,
-          fail: :boolean,
+          fail_fast: :boolean,
           cwd: :string
         ]
       )
@@ -58,7 +58,7 @@ defmodule Mix.Tasks.Lcov.Run do
     test_params =
       ["--cover", "--color"] ++
         if(app_path, do: [Path.join("#{app_path}", "test")], else: []) ++
-        if(opts[:fail], do: ["--max-failures", "1"], else: [])
+        if(opts[:fail_fast], do: ["--max-failures", "1"], else: [])
 
     # Run tests with updated :test_coverage configuration
     Mix.Task.run("test", test_params)

--- a/lib/tasks/lcov.run.ex
+++ b/lib/tasks/lcov.run.ex
@@ -22,6 +22,7 @@ defmodule Mix.Tasks.Lcov.Run do
           keep: :boolean,
           output: :string,
           exit: :boolean,
+          fail: :boolean,
           cwd: :string
         ]
       )
@@ -55,7 +56,9 @@ defmodule Mix.Tasks.Lcov.Run do
     Mix.ProjectStack.push(project, new_config, mix_path)
 
     test_params =
-      ["--cover", "--color"] ++ if app_path, do: [Path.join("#{app_path}", "test")], else: []
+      ["--cover", "--color"] ++
+        if(app_path, do: [Path.join("#{app_path}", "test")], else: []) ++
+        if(opts[:fail], do: ["--max-failures", "1"], else: [])
 
     # Run tests with updated :test_coverage configuration
     Mix.Task.run("test", test_params)

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule LcovEx.MixProject do
   use Mix.Project
 
-  @version "0.3.3"
+  @version "0.3.4"
 
   def project do
     [

--- a/test/tasks/lcov_test.exs
+++ b/test/tasks/lcov_test.exs
@@ -62,15 +62,15 @@ defmodule LcovEx.Tasks.LcovTest do
       assert output =~ "2 tests, 2 failures"
     end
 
-    test "mix lcov --fail exits the run at the first failed test" do
-      assert {output, 0} = System.cmd("mix", ["lcov", "--fail"], cd: "example_failing_project")
+    test "mix lcov --fail-fast exits the run at the first failed test" do
+      assert {output, 0} = System.cmd("mix", ["lcov", "--fail-fast"], cd: "example_failing_project")
 
       assert output =~ "--max-failures reached, aborting test suite"
       assert output =~ "1 test, 1 failure"
     end
 
-    test "mix lcov --exit --fail returns a non-zero code at the first failed test" do
-      assert {output, 2} = System.cmd("mix", ["lcov", "--fail", "--exit"], cd: "example_failing_project")
+    test "mix lcov --exit --fail-fast returns a non-zero code at the first failed test" do
+      assert {output, 2} = System.cmd("mix", ["lcov", "--fail-fast", "--exit"], cd: "example_failing_project")
 
       assert output =~ "--max-failures reached, aborting test suite"
       assert output =~ "1 test, 1 failure"

--- a/test/tasks/lcov_test.exs
+++ b/test/tasks/lcov_test.exs
@@ -59,6 +59,21 @@ defmodule LcovEx.Tasks.LcovTest do
 
       assert output =~ "Generating lcov file..."
       assert output =~ "Coverage file created at cover/lcov.info"
+      assert output =~ "2 tests, 2 failures"
+    end
+
+    test "mix lcov --fail exits the run at the first failed test" do
+      assert {output, 0} = System.cmd("mix", ["lcov", "--fail"], cd: "example_failing_project")
+
+      assert output =~ "--max-failures reached, aborting test suite"
+      assert output =~ "1 test, 1 failure"
+    end
+
+    test "mix lcov --exit --fail returns a non-zero code at the first failed test" do
+      assert {output, 2} = System.cmd("mix", ["lcov", "--fail", "--exit"], cd: "example_failing_project")
+
+      assert output =~ "--max-failures reached, aborting test suite"
+      assert output =~ "1 test, 1 failure"
     end
   end
 


### PR DESCRIPTION
The new flag adds the `--max-failures 1` option to the `mix test` call, so `mix lcov --fail-fast --exit` breaks CI as soon as a test fails.