### PR TITLE
pass through partitions and no compile args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 lcov_ex-*.tar
 
+# Ignore expert ls
+.expert/

--- a/lib/tasks/lcov.ex
+++ b/lib/tasks/lcov.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.Lcov do
   def run(args) do
     {opts, files} =
       OptionParser.parse!(args,
-        strict: [quiet: :boolean, keep: :boolean, output: :string, exit: :boolean, fail_fast: :boolean, partitions: :integer]
+        strict: [quiet: :boolean, keep: :boolean, output: :string, exit: :boolean, fail_fast: :boolean, partitions: :integer, no_compile: :boolean]
       )
 
     if opts[:quiet], do: Mix.shell(Mix.Shell.Quiet)

--- a/lib/tasks/lcov.ex
+++ b/lib/tasks/lcov.ex
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.Lcov do
   def run(args) do
     {opts, files} =
       OptionParser.parse!(args,
-        strict: [quiet: :boolean, keep: :boolean, output: :string, exit: :boolean, fail_fast: :boolean]
+        strict: [quiet: :boolean, keep: :boolean, output: :string, exit: :boolean, fail_fast: :boolean, partitions: :integer]
       )
 
     if opts[:quiet], do: Mix.shell(Mix.Shell.Quiet)

--- a/lib/tasks/lcov.run.ex
+++ b/lib/tasks/lcov.run.ex
@@ -23,7 +23,8 @@ defmodule Mix.Tasks.Lcov.Run do
           output: :string,
           exit: :boolean,
           fail_fast: :boolean,
-          cwd: :string
+          cwd: :string,
+          partitions: :integer
         ]
       )
 
@@ -58,7 +59,8 @@ defmodule Mix.Tasks.Lcov.Run do
     test_params =
       ["--cover", "--color"] ++
         if(app_path, do: [Path.join("#{app_path}", "test")], else: []) ++
-        if(opts[:fail_fast], do: ["--max-failures", "1"], else: [])
+        if(opts[:fail_fast], do: ["--max-failures", "1"], else: []) ++
+        if(opts[:partitions], do: ["--partitions", "#{opts[:partitions]}"], else: [])
 
     # Run tests with updated :test_coverage configuration
     Mix.Task.run("test", test_params)

--- a/lib/tasks/lcov.run.ex
+++ b/lib/tasks/lcov.run.ex
@@ -24,7 +24,8 @@ defmodule Mix.Tasks.Lcov.Run do
           exit: :boolean,
           fail_fast: :boolean,
           cwd: :string,
-          partitions: :integer
+          partitions: :integer,
+          no_compile: :boolean
         ]
       )
 
@@ -60,7 +61,8 @@ defmodule Mix.Tasks.Lcov.Run do
       ["--cover", "--color"] ++
         if(app_path, do: [Path.join("#{app_path}", "test")], else: []) ++
         if(opts[:fail_fast], do: ["--max-failures", "1"], else: []) ++
-        if(opts[:partitions], do: ["--partitions", "#{opts[:partitions]}"], else: [])
+        if(opts[:partitions], do: ["--partitions", "#{opts[:partitions]}"], else: []) ++
+        if(opts[:no_compile], do: ["--no-compile"], else: [])
 
     # Run tests with updated :test_coverage configuration
     Mix.Task.run("test", test_params)

--- a/test/tasks/lcov_test.exs
+++ b/test/tasks/lcov_test.exs
@@ -88,6 +88,16 @@ defmodule LcovEx.Tasks.LcovTest do
 
       assert File.read!("example_project/cover/lcov.info") == output()
     end
+
+    test "mix lcov --no-compile skips compilation" do
+      assert {output, 0} =
+               System.cmd("mix", ["lcov", "--no-compile"], cd: "example_project")
+
+      assert output =~ "Generating lcov file..."
+      assert output =~ "Coverage file created at cover/lcov.info"
+
+      assert File.read!("example_project/cover/lcov.info") == output()
+    end
   end
 
   describe "ExampleUmbrellaProject" do

--- a/test/tasks/lcov_test.exs
+++ b/test/tasks/lcov_test.exs
@@ -75,6 +75,19 @@ defmodule LcovEx.Tasks.LcovTest do
       assert output =~ "--max-failures reached, aborting test suite"
       assert output =~ "1 test, 1 failure"
     end
+
+    test "mix lcov --partitions passes partitions to mix test" do
+      assert {output, 0} =
+               System.cmd("mix", ["lcov", "--partitions", "2"],
+                 cd: "example_project",
+                 env: [{"MIX_TEST_PARTITION", "1"}]
+               )
+
+      assert output =~ "Generating lcov file..."
+      assert output =~ "Coverage file created at cover/lcov.info"
+
+      assert File.read!("example_project/cover/lcov.info") == output()
+    end
   end
 
   describe "ExampleUmbrellaProject" do


### PR DESCRIPTION
```
--partitions - sets the amount of partitions to split tests in. It must be a number greater than zero. If set to one, it acts a no-op. If more than one, then you must also set the MIX_TEST_PARTITION environment variable with the partition to use in the current test run. See the "Operating system process partitioning" section for more information

--no-compile - does not compile, even if files require compilation
```

partitions arg with test showing the required MIX_TEST_PARTITION env, and no compile arg